### PR TITLE
chore: add example of remap

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Add `zinit load zdharma-continuum/zbrowse` to your `.zshrc` file. zinit will han
 plugin for you automatically the next time you start zsh. To update run
 `zinit update zdharma-continuum/zbrowse` (`update-all` can also be used).
 
+To remap the default bindkey (Ctrl+B) which conflicts with GNU readline, do the following:
+```zsh
+zinit ice wait"3" trackbinds bindmap"^B -> ^H; lucid
+zinit light zdharma-continuum/zbrowse
+```
+
+This will make Ctrl+H the default keybinding to invoke zbrowse.
+
 ### Antigen
 
 Add `antigen bundle zdharma-continuum/zbrowse` to your `.zshrc` file. Antigen will handle cloning


### PR DESCRIPTION
Add bindkey examples to documentation
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->
Simply added a snippet showing how to remap the default keymapping to invoke zbrowse. This seems useful because the default binding conflicts with the GNU readline flavor of navigation in bash.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
It shows how to use zbrowse and GNU readline together.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh
zinit ice wait"3" trackbinds bindmap"^B -> ^H; lucid
zinit light zdharma-continuum/zbrowse
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

I have been using it in my `.zshrc` for a long time. zinit in genral suffers from an approachability problem, and examples like these help clarify things that could otherwise cause confusion among users.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [X ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.

Thanks for your consideration- I have grown fond of zinit and like to give back to the project. ty ❤️  @vladdoster 
